### PR TITLE
fix el9 build

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2896,7 +2896,7 @@ AV *dbd_st_fetch( SV *sth,
               if( longTruncOk )
                 warn( "%s", msg );
               else
-                croak( msg );
+                croak("%s", msg);
             }
             else if( ChopBlanks && SQL_CHAR == fbh->dbtype )
               sv_setpvn( sv,


### PR DESCRIPTION
On el9 systems, build fail (using cpan or manually)  with the following error 

```
dbdimp.c:2899:24: error: format not a string literal and no format arguments [-Werror=format-security]
 2899 |                 croak( msg );
      |                        ^~~
```