### PR TITLE
DBC-14689: Enhance perl-DBD-DB2 driver to read Db2 credential from En…

### DIFF
--- a/tests/connection.pl
+++ b/tests/connection.pl
@@ -1,5 +1,17 @@
-$USERID="userid";
-$PASSWORD="password";
+$USERID=  $ENV{'DB2_USER'};
+$lenu = length($USERID);
+if($lenu == 0){
+print "Environment variables DB2_USER and DB2_PASSWD are not set. Please set it before running test file. Using config file values.\n";
+$USERID="uid";
+}
+
+$PASSWORD =  $ENV{'DB2_PASSWD'};
+$lenp = length($PASSWORD);
+if($lenp == 0){
+print "Environment variables DB2_USER and DB2_PASSWD are not set. Please set it before running test file. Using config file values.\n";
+$PASSWORD="pwd";
+}
+
 $PORT=50000;
 $HOSTNAME="localhost";
 $DATABASE="database";


### PR DESCRIPTION
Enhance perl-DBD-DB2 driver to read Db2 credential from Env vars DB2_USER and DB2_PASSWD for testing instead of reading it from config.json file. Use the credential of config.json only if env var is not set. Read database userid and passwd from environment variable, append to connection string and then proceed for connection in a test file. Print warning message to set these env vars if it is not set before running the test file as "Environment variables DB2_USER and DB2_PASSWD are not set. Please set it before running test file."